### PR TITLE
Diff tiles from Mapbox Studio with our own

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
   - npm install -g pixelmatch
-  - mkdir -p ./export && cd ./export && git clone https://github.com/mapbox/mapbox-studio-osm-bright.tm2.git
+  - mkdir -p export && git clone https://github.com/mapbox/mapbox-studio-osm-bright.tm2.git export/mapbox-studio-osm-bright.tm2
 install:
   - docker-compose build
 before_script:
@@ -15,6 +15,9 @@ before_script:
   - sleep 5
 script:
   - docker-compose run imposm3
+  - tree
   - docker-compose run tilelive && mv export/tiles.mbtiles export/mapbox-studio-osm-bright.mbtiles
   - docker-compose up -d tileserver && sleep 1
-  - bash ./test/scrape_diff_test.sh
+  - bash test/scrape_diff_test.sh
+after_script:
+  - bash test/upload_diffs_github.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 language: node_js
+node_js:
+  - "0.12"
 services:
   - docker
 before_install:
@@ -15,9 +17,9 @@ before_script:
   - sleep 5
 script:
   - docker-compose run imposm3
-  - tree
   - docker-compose run tilelive && mv export/tiles.mbtiles export/mapbox-studio-osm-bright.mbtiles
   - docker-compose up -d tileserver && sleep 1
   - bash test/scrape_diff_test.sh
 after_script:
+  - ls -la test
   - bash test/upload_diffs_github.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,20 @@
 sudo: required
-language: bash
+language: node_js
 services:
   - docker
 before_install:
   - curl -L https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+  - npm install -g pixelmatch
+  - mkdir -p ./export && cd ./export && git clone https://github.com/mapbox/mapbox-studio-osm-bright.tm2.git
 install:
   - docker-compose build
 before_script:
   - docker-compose up -d postgis
-  - sleep 10
+  - sleep 5
 script:
   - docker-compose run imposm3
-  - docker-compose run tilelive
-  - docker-compose up -d tileserver
-  - sleep 5
-  - curl "http://localhost:8080/index.json"
+  - docker-compose run tilelive && mv export/tiles.mbtiles export/mapbox-studio-osm-bright.mbtiles
+  - docker-compose up -d tileserver && sleep 1
+  - bash ./test/scrape_diff_test.sh

--- a/test/scrape_diff_test.sh
+++ b/test/scrape_diff_test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+readonly CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly LOCAL_DIR="$CWD/local"
+readonly MAPBOX_DIR="$CWD/mapbox"
+readonly DIFF_DIR="$CWD/diff"
+readonly LOCAL_BASE_URL="http://localhost:8080"
+
+readonly MAPBOX_OSM_BRIGHT_ID="morgenkaffee.9c069ced"
+readonly MAPBOX_BASE_URL="https://api.mapbox.com/v4/$MAPBOX_OSM_BRIGHT_ID"
+readonly MAPBOX_ACCESS_TOKEN="pk.eyJ1IjoibW9yZ2Vua2FmZmVlIiwiYSI6ImNpZnNpMHRyMzAwazB0Nm03c2syeXV3ZzgifQ.FtkzQBLU67QvhJu1M-7xbw"
+
+readonly PIXELMATCH_BIN="pixelmatch"
+
+function download_tile() {
+    local base_url=$1
+    local q=$2
+    local z=$3
+    local x=$4
+    local y=$5
+    echo "$base_url/$z/$x/$y.png$q"
+    curl -o $z"_"$x"_"$y.png "$base_url/$z/$x/$y.png$q"
+}
+
+function download_tiles_from_local() {
+    mkdir -p $LOCAL_DIR
+    cd $LOCAL_DIR
+    download_tile $LOCAL_BASE_URL "" 15 17161 11475
+    download_tile $LOCAL_BASE_URL "" 13 4290 2868
+    download_tile $LOCAL_BASE_URL "" 12 2145 1434
+    download_tile $LOCAL_BASE_URL "" 11 1072 717
+    download_tile $LOCAL_BASE_URL "" 10 536 358
+    download_tile $LOCAL_BASE_URL "" 9 268 179
+    cd $CWD
+}
+
+function download_tiles_from_mapbox() {
+    mkdir -p $MAPBOX_DIR
+    cd $MAPBOX_DIR
+    local q="?access_token=$MAPBOX_ACCESS_TOKEN"
+    download_tile $MAPBOX_BASE_URL "$q" 15 17161 11475
+    download_tile $MAPBOX_BASE_URL "$q" 13 4290 2868
+    download_tile $MAPBOX_BASE_URL "$q" 12 2145 1434
+    download_tile $MAPBOX_BASE_URL "$q" 11 1072 717
+    download_tile $MAPBOX_BASE_URL "$q" 10 536 358
+    download_tile $MAPBOX_BASE_URL "$q" 9 268 179
+    cd $CWD
+}
+
+function make_diffs() {
+    mkdir -p $DIFF_DIR
+    cd $MAPBOX_DIR
+
+    local filepath
+    for filepath in "$LOCAL_DIR"/*.png; do
+        local filename=$(basename "$filepath")
+        $PIXELMATCH_BIN $LOCAL_DIR/$filename $MAPBOX_DIR/$filename $DIFF_DIR/$filename 0.005 1
+    done
+
+    cd $CWD
+}
+
+download_tiles_from_mapbox
+download_tiles_from_local
+make_diffs

--- a/test/upload_diffs_github.sh
+++ b/test/upload_diffs_github.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+readonly CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly DIFF_DIR="$CWD/local"
+
+readonly GIT_USERNAME="Travis CI"
+readonly GIT_EMAIL="me@lukasmartinelli.ch"
+
+function commit_latest_diffs() {
+    git clone https://github.com/geometalab/osm2vectortiles.git repo
+
+    cd repo
+    git checkout gh-pages
+    cp -rf "$CWD/test/diffs" "diffs"
+
+    git config user.name "$GIT_USERNAME"
+    git config user.email "$GIT_EMAIL"
+    git config credential.helper "store --file=.git/credentials"
+    echo "https://${GH_TOKEN}:@github.com" > .git/credentials
+
+    git add diffs/*
+    git commit -m "Add latest tile diffs from ${TRAVIS_BUILD_NUMBER}"
+    git push origin gh-pages
+
+    cd $CWD
+}

--- a/test/upload_diffs_github.sh
+++ b/test/upload_diffs_github.sh
@@ -14,16 +14,18 @@ function commit_latest_diffs() {
 
     cd repo
     git checkout gh-pages
-    cp -rf "$CWD/test/diffs" "diffs"
+    cp -rf "$CWD/diff" "diff"
 
     git config user.name "$GIT_USERNAME"
     git config user.email "$GIT_EMAIL"
     git config credential.helper "store --file=.git/credentials"
     echo "https://${GH_TOKEN}:@github.com" > .git/credentials
 
-    git add diffs/*
+    git add diff/*
     git commit -m "Add latest tile diffs from ${TRAVIS_BUILD_NUMBER}"
     git push origin gh-pages
 
     cd $CWD
 }
+
+commit_latest_diffs

--- a/tileserver/run.sh
+++ b/tileserver/run.sh
@@ -83,4 +83,4 @@ function serve_style() {
         --source-cache-size $SOURCE_CACHE_SIZE
 }
 
-serve_style $DEST_PROJECT_DIR"
+serve_style "$DEST_PROJECT_DIR"


### PR DESCRIPTION
This is based on the cool idea of @manuelroth to use visual regression testing for our tiles.
Its crazy how well those diffs work.

For every commit we compare our own OSM-Bright tiles with Mapbox OSM-Bright tiles.
The diff is uploaded to the `gh-pages` branch below `diffs` for every build.
Perhaps there is a smarter idea for that.

![add_latest_tile_diffs_from_56_ _geometalab_osm2vectortiles_3a54aa2](https://cloud.githubusercontent.com/assets/1288339/10524146/5752befa-737e-11e5-9520-94b528b7419b.jpg)

It can also be used manually and generates diffs and make comparing easy.
![test](https://cloud.githubusercontent.com/assets/1288339/10524173/72d19674-737e-11e5-819b-ca3d58db25f0.jpg)

The diffs are so cool.

Mapbox Streets:
![15_17161_11475](https://cloud.githubusercontent.com/assets/1288339/10524175/767f721e-737e-11e5-88ea-3a4363562153.png)
Openstreets:
![15_17161_11475](https://cloud.githubusercontent.com/assets/1288339/10524181/7dd706bc-737e-11e5-86e8-845dc9f4d600.png)
Diff:
![15_17161_11475](https://cloud.githubusercontent.com/assets/1288339/10524187/805c54aa-737e-11e5-9235-04edc10e4d99.png)


If we really want to take it to the next level we could actually use the `tl` utility to
1. scrape some tiles from mapbox with tl
2. scrape some tiles from our server with til
3. make the diffs of all of them
4. use tl again to package the diff into a new raster mbtiles
5. and have a crazy raster **map**!!! of the changes

