### PR TITLE
Move classifying into SQL functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
   - docker-compose up -d postgis
   - sleep 10
   - docker-compose run import-water
+  - docker-compose run prepare-open-streets
   - docker-compose run import
   - docker-compose run export
   - docker-compose up -d serve

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,3 +48,7 @@ mapbox-studio:
    - postgis:db
   ports:
    - "3000:3000"
+prepare-open-streets:
+  build: ./src/prepare-open-streets
+  links:
+   - postgis:db

--- a/open-streets.tm2source/data.yml
+++ b/open-streets.tm2source/data.yml
@@ -288,16 +288,7 @@ Layer:
       table: |-
         ( SELECT geometry,
           osm_id,
-          CASE
-            WHEN type IN ('motorway', 'trunk') THEN 'motorway'
-            WHEN type IN ('primary', 'secondary', 'tertiary') THEN 'main'
-            WHEN type IN ('motorway_link', 'trunk_link', 'primary_link', 'tertiary_link') THEN 'motorway_link'
-            WHEN type IN ('secondary_link', 'residential', 'unclassified', 'road') THEN 'street'
-            WHEN type IN ('living_street', 'pedestrian') THEN 'street_limited'        
-            WHEN type IN ('service', 'track') THEN 'service'
-            WHEN type IN ('path', 'cycleway', 'footway', 'steps', 'bridleway') THEN 'path'
-            WHEN type IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') THEN 'major_rail'
-            ELSE 'other' END AS class,
+          classify_road(type) as class,
           type,
           layer,
           oneway
@@ -333,18 +324,7 @@ Layer:
       table: |-
         (
           SELECT geometry, osm_id, type,
-            CASE
-              WHEN type IN ('motorway', 'trunk') THEN 'motorway'
-              WHEN type IN ('primary', 'secondary', 'tertiary') THEN 'main'
-              WHEN type IN ('motorway_link', 'trunk_link') THEN 'motorway_link'
-              WHEN type IN ('primary_link', 'secondary_link', 'tertiary_link', 'residential', 'unclassified', 'road') THEN 'street'
-              WHEN type IN ('living_street', 'pedestrian') THEN 'street_limited'        
-              WHEN type IN ('service', 'track') THEN 'service'
-              WHEN type IN ('path', 'cycleway', 'footway', 'steps', 'bridleway') THEN 'path'
-              --railways
-              WHEN type IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') THEN 'major_rail'
-              WHEN type IN ('funicular', 'light_rail', 'preserved') THEN 'minor_rail'
-              ELSE 'other' END AS class
+          classify_road(type) as class
           FROM (
               SELECT osm_id, geometry, type FROM osm_roads_gen1
               WHERE geometry && !bbox!
@@ -388,16 +368,7 @@ Layer:
       table: |-
         ( SELECT geometry,
           osm_id,
-          CASE
-            WHEN type IN ('motorway', 'trunk') THEN 'motorway'
-            WHEN type IN ('primary', 'secondary', 'tertiary') THEN 'main'
-            WHEN type IN ('motorway_link', 'trunk_link', 'primary_link', 'tertiary_link') THEN 'motorway_link'
-            WHEN type IN ('secondary_link', 'residential', 'unclassified', 'road') THEN 'street'
-            WHEN type IN ('living_street', 'pedestrian') THEN 'street_limited'        
-            WHEN type IN ('service', 'track') THEN 'service'
-            WHEN type IN ('path', 'cycleway', 'footway', 'steps', 'bridleway') THEN 'path'
-            WHEN type IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') THEN 'major_rail'
-            ELSE 'other' END AS class,
+          classify_road(type) as class,
           type,
           layer,
           oneway
@@ -727,7 +698,7 @@ Layer:
                 else 4 end
               as scalerank, 
               1 as localrank,
-              replace(type, '_', '-') as maki
+              maki_label(type) as maki
             from (
               select geometry,
               osm_id, name, name_de, name_en, name_es, name_fr, type, 0 as area
@@ -781,16 +752,7 @@ Layer:
             ref,
             char_length(ref) as reflen,
             round(MercLength(geometry)) as len,
-            CASE
-        	  WHEN type IN ('motorway', 'motorway_link', 'driveway') THEN 'highway'
-        	  WHEN type IN ('primary', 'primary_link', 'trunk', 'trunk_link', 'secondary', 'secondary_link', 'tertiary', 'tertiary_link') THEN 'main'
-        	  WHEN type IN ('residential', 'unclassified', 'living_street') THEN 'street'
-        	  WHEN type IN ('pedestrian', 'construction', 'private') THEN 'street_limited'
-        	  WHEN type IN ('rail', 'monorail', 'narrow_gauge', 'subway', 'tram') THEN 'major_rail'
-        	  WHEN type IN ('service', 'track') THEN 'service'
-        	  WHEN type IN ('path', 'cycleway', 'ski', 'steps', 'bridleway', 'footway') THEN 'path'
-        	  WHEN type IN ('funicular', 'light_rail', 'preserved') THEN 'minor_rail'
-            END AS class
+            classify_road(type) as class
             FROM osm_roads
             WHERE
             geometry && !bbox! AND

--- a/open-streets.tm2source/data.yml
+++ b/open-streets.tm2source/data.yml
@@ -26,21 +26,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id, geometry,
-          CASE
-            WHEN type IN ('orchard', 'farm', 'farmland', 'farmyard', 'allotments', 'vineyard', 'plant_nursery') THEN 'agriculture'
-            WHEN type IN ('cemetery','christian', 'jewish') THEN 'cemetery'
-            WHEN type IN ('glacier') THEN 'glacier'
-            WHEN type IN ('grass', 'grassland', 'meadow') THEN 'grass'
-            WHEN type IN ('hospital') THEN 'hospital'
-            WHEN type IN ('industrial') THEN 'industrial'
-            WHEN type IN ('park', 'dog_park', 'common', 'garden', 'golf_course', 'playground', 'recreation_ground', 'nature_reserve', 'sports_centre', 'village_green', 'zoo') THEN 'park'
-            WHEN type IN ('athletics', 'chess', 'pitch') THEN 'pitch'
-            WHEN type IN ('sand') THEN 'sand'
-            WHEN type IN ('school', 'college', 'university') THEN 'school'
-            WHEN type IN ('scrub') THEN 'scrub'
-            WHEN type IN ('wood', 'forest') THEN 'wood'
-            END AS class
+          SELECT osm_id, geometry, classify_landuse(type) as class
           FROM (
             SELECT osm_id, geometry, type FROM osm_landusages_gen0
             WHERE geometry && !bbox!

--- a/src/prepare-open-streets/Dockerfile
+++ b/src/prepare-open-streets/Dockerfile
@@ -1,14 +1,9 @@
 FROM mdillon/postgis:9.4
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN git clone https://github.com/geometalab/open-streets.tm2source /usr/src/app
+RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
+COPY functions.sql /usr/src/app/functions.sql
 ENV SQL_FILE=/usr/src/app/functions.sql
 
 COPY prepare.sh /usr/src/app/
-
 CMD ["./prepare.sh"]

--- a/src/prepare-open-streets/Dockerfile
+++ b/src/prepare-open-streets/Dockerfile
@@ -1,0 +1,14 @@
+FROM mdillon/postgis:9.4
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/geometalab/open-streets.tm2source /usr/src/app
+WORKDIR /usr/src/app
+ENV SQL_FILE=/usr/src/app/functions.sql
+
+COPY prepare.sh /usr/src/app/
+
+CMD ["./prepare.sh"]

--- a/src/prepare-open-streets/functions.sql
+++ b/src/prepare-open-streets/functions.sql
@@ -6,10 +6,10 @@ BEGIN
         WHEN type IN ('primary', 'primary_link', 'trunk', 'trunk_link', 'secondary', 'secondary_link', 'tertiary', 'tertiary_link') THEN 'main'
         WHEN type IN ('residential', 'unclassified', 'living_street') THEN 'street'
         WHEN type IN ('pedestrian', 'construction', 'private') THEN 'street_limited'
-        WHEN type IN ('rail', 'monorail', 'narrow_gauge', 'subway', 'tram') THEN 'major_rail'
         WHEN type IN ('service', 'track') THEN 'service'
         WHEN type IN ('path', 'cycleway', 'ski', 'steps', 'bridleway', 'footway') THEN 'path'
-        WHEN type IN ('funicular', 'light_rail', 'preserved') THEN 'minor_rail'
+        WHEN type IN ('rail', 'monorail', 'narrow_gauge', 'subway') THEN 'major_rail'
+        WHEN type IN ('funicular', 'light_rail', 'preserved', 'tram') THEN 'minor_rail'
     END;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;

--- a/src/prepare-open-streets/functions.sql
+++ b/src/prepare-open-streets/functions.sql
@@ -14,6 +14,26 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
+CREATE OR REPLACE FUNCTION classify_landuse(type VARCHAR) RETURNS VARCHAR
+AS $$
+BEGIN
+    RETURN CASE
+        WHEN type IN ('orchard', 'farm', 'farmland', 'farmyard', 'allotments', 'vineyard', 'plant_nursery') THEN 'agriculture'
+        WHEN type IN ('cemetery','christian', 'jewish') THEN 'cemetery'
+        WHEN type IN ('glacier') THEN 'glacier'
+        WHEN type IN ('grass', 'grassland', 'meadow') THEN 'grass'
+        WHEN type IN ('hospital') THEN 'hospital'
+        WHEN type IN ('industrial') THEN 'industrial'
+        WHEN type IN ('park', 'dog_park', 'common', 'garden', 'golf_course', 'playground', 'recreation_ground', 'nature_reserve', 'sports_centre', 'village_green', 'zoo') THEN 'park'
+        WHEN type IN ('athletics', 'chess', 'pitch') THEN 'pitch'
+        WHEN type IN ('sand') THEN 'sand'
+        WHEN type IN ('school', 'college', 'university') THEN 'school'
+        WHEN type IN ('scrub') THEN 'scrub'
+        WHEN type IN ('wood', 'forest') THEN 'wood'
+    END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
 CREATE OR REPLACE FUNCTION maki_label(class VARCHAR) RETURNS VARCHAR
 AS $$
 BEGIN

--- a/src/prepare-open-streets/functions.sql
+++ b/src/prepare-open-streets/functions.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION classify_road(type VARCHAR) RETURNS VARCHAR
+AS $$
+BEGIN
+    RETURN CASE
+        WHEN type IN ('motorway', 'motorway_link', 'driveway') THEN 'highway'
+        WHEN type IN ('primary', 'primary_link', 'trunk', 'trunk_link', 'secondary', 'secondary_link', 'tertiary', 'tertiary_link') THEN 'main'
+        WHEN type IN ('residential', 'unclassified', 'living_street') THEN 'street'
+        WHEN type IN ('pedestrian', 'construction', 'private') THEN 'street_limited'
+        WHEN type IN ('rail', 'monorail', 'narrow_gauge', 'subway', 'tram') THEN 'major_rail'
+        WHEN type IN ('service', 'track') THEN 'service'
+        WHEN type IN ('path', 'cycleway', 'ski', 'steps', 'bridleway', 'footway') THEN 'path'
+        WHEN type IN ('funicular', 'light_rail', 'preserved') THEN 'minor_rail'
+    END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION maki_label(class VARCHAR) RETURNS VARCHAR
+AS $$
+BEGIN
+    RETURN REPLACE(class, '_', '-');
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/src/prepare-open-streets/prepare.sh
+++ b/src/prepare-open-streets/prepare.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+readonly SQL_FILE=${IMPORT_DATA_DIR:-/usr/src/app/functions.sql}
+
+readonly DB_HOST=$DB_PORT_5432_TCP_ADDR
+readonly OSM_DB=${OSM_DB:-osm}
+readonly OSM_USER=${OSM_USER:-osm}
+readonly OSM_PASSWORD=${OSM_PASSWORD:-osm}
+
+function exec_sql_file() {
+	local sql_file=$1
+	PG_PASSWORD=$OSM_PASSWORD psql --host="$DB_HOST" --port=5432 --dbname="$OSM_DB" --username="$OSM_USER" -a -f "$sql_file"
+}
+
+function main() {
+    echo "Creating functions in $OSM_DB necessary for open-streets"
+    exec_sql_file "$SQL_FILE"
+}
+
+main


### PR DESCRIPTION
Now we have a `prepare-open-streets` container (better name welcome) that needs to run to update the functions.
Works quite well for working with it -> change something in `functions.sql` and then build and run the container.

Integrating it into `import-water` might be possible but because one does iterate on the functions quite often (and does not want to import the water all the time).

By making the functions immutable we might also later on add an index over the function, but I think the `CASE WHEN` stuff in the `SELECT` clause does not add much overhead on the query.